### PR TITLE
Refactor User Facing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ type FooApi =
 From the tests:
 
 ```
-  let reifiedApi = RS.toReifiedApi (RS.flattenServer @Foo.FooApi Foo.fooServer) (Proxy @(Endpoints Foo.FooApi))
   assert "should find an error in Foo" . not
-    =<< checkSequential (Group "Foo" [("Foo", RS.prop_sequential reifiedApi)])
+    =<< checkSequential (Group "Foo" [("Foo", RS.prop_sequential @Foo.FooApi Foo.fooServer)])
 ```
 
 We have a server that blows up if the value of the int in a `Foo` ever gets above 10. Note:

--- a/package.yaml
+++ b/package.yaml
@@ -7,7 +7,7 @@ maintainer:          "mwotton@gmail.com"
 copyright:           "2020 Mark Wotton, Samuel Schlesinger"
 synopsis:            Automatic session-aware servant testing
 category:            Web
-description:         Please see the README on GitHub at <https://github.com/githubuser/roboservant#readme>
+description:         Please see the README on GitHub at <https://github.com/mwotton/roboservant#readme>
 
 extra-source-files:
 - README.md

--- a/roboservant.cabal
+++ b/roboservant.cabal
@@ -4,12 +4,12 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 51154f1c866aea92673a52985de6810cebda3b2662fddd7b7f88a56725e30041
+-- hash: 83f44d7e193afdbe2e62584983f73420b90328cbc0ea01f626d16313091641cf
 
 name:           roboservant
 version:        0.1.0.0
 synopsis:       Automatic session-aware servant testing
-description:    Please see the README on GitHub at <https://github.com/githubuser/roboservant#readme>
+description:    Please see the README on GitHub at <https://github.com/mwotton/roboservant#readme>
 category:       Web
 homepage:       https://github.com/mwotton/roboservant#readme
 bug-reports:    https://github.com/mwotton/roboservant/issues

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
-import Data.Proxy (Proxy (..))
 import qualified Foo
 import Hedgehog (Group (..), checkSequential)
 import qualified Roboservant as RS
-import Servant (Endpoints)
 import qualified UnsafeIO
 
 -- | this is pretty bad. hopefully Jacob knows a better way of doing this.

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -17,15 +17,13 @@ assert err False = ioError $ userError err
 -- | This is horribly laid out, sorry. Will fix at some point.
 main :: IO ()
 main = do
-  let reifiedApi = RS.toReifiedApi (RS.flattenServer @Foo.FooApi Foo.fooServer) (Proxy @(Endpoints Foo.FooApi))
   assert "should find an error in Foo" . not
-    =<< checkSequential (Group "Foo" [("Foo", RS.prop_sequential reifiedApi)])
+    =<< checkSequential (Group "Foo" [("Foo", RS.prop_sequential @Foo.FooApi Foo.fooServer)])
   -- The UnsafeIO checker does not actually really use the contextually aware stuff, though it
   -- could: it's mostly here to show how to test for concurrency problems.
   unsafeServer <- UnsafeIO.makeServer
-  let unsafeApi = RS.toReifiedApi (RS.flattenServer @UnsafeIO.UnsafeApi unsafeServer) (Proxy @(Endpoints UnsafeIO.UnsafeApi))
   -- this will not detect the error, as it requires concurrency.
-  assert "should find nothing" =<< checkSequential (Group "Unsafe" [("Sequential", RS.prop_sequential unsafeApi)])
+  assert "should find nothing" =<< checkSequential (Group "Unsafe" [("Sequential", RS.prop_sequential @UnsafeIO.UnsafeApi unsafeServer)])
   -- this will!
   assert "should find with parallel check" . not
-    =<< checkSequential (Group "Unsafe" [("Parallel", RS.prop_concurrent unsafeApi)])
+    =<< checkSequential (Group "Unsafe" [("Parallel", RS.prop_concurrent @UnsafeIO.UnsafeApi unsafeServer)])


### PR DESCRIPTION
I think the type level internals should not be exposed to the user in any meaningful way, but they should just be able to build nice tests given a servant server that satisfies the flat shape we expect.