### PR TITLE
match ServantT type family for Capture'

### DIFF
--- a/src/Roboservant/Types/ReifiedApi.hs
+++ b/src/Roboservant/Types/ReifiedApi.hs
@@ -182,14 +182,14 @@ instance
 
 -- this isn't happy in 0.16.2
 instance
-  ( BuildFrom (IfLenient String mods captureType)
+  ( BuildFrom captureType
   , ToReifiedEndpoint endpoint) =>
   ToReifiedEndpoint (Capture' mods name captureType :> endpoint)
   where
-  type EndpointArgs (Capture' mods name captureType :> endpoint) = IfLenient String mods captureType ': EndpointArgs endpoint
+  type EndpointArgs (Capture' mods name captureType :> endpoint) = captureType ': EndpointArgs endpoint
   type EndpointRes  (Capture' mods name captureType :> endpoint) = EndpointRes endpoint
   reifiedEndpointArguments =
-   tagType (Argument (buildFrom @(IfLenient String mods captureType)))
+   tagType (Argument (buildFrom @(captureType)))
       V.:& reifiedEndpointArguments @endpoint
 
 instance


### PR DESCRIPTION
Main issue is that the type you cons onto `EndpointArgs` has to match the `ServerT` type family.  So in 0.16.2, `ServerT` for `Capture'` is

```
  type ServerT (Capture' mods capture a :> api) m =
     a -> ServerT api m
```

So you would cons on just literally `a`.

I believe in the past, it used to be the case that

```
  type ServerT (Capture' mods capture a :> api) m =
     IfLenient String mods a -> ServerT api m
```

so the previous implementation would have worked

There might be a nice way to do this automatically that works in both cases (like, use a type family to extract the argument)