### PR TITLE
Add trace check hooks

### DIFF
--- a/roboservant.cabal
+++ b/roboservant.cabal
@@ -114,6 +114,7 @@ test-suite roboservant-test
       Foo
       Headers
       MinithesisExample
+      MinithesisAuth
       Nested
       Post
       Product

--- a/src/Roboservant/Types/Config.hs
+++ b/src/Roboservant/Types/Config.hs
@@ -1,6 +1,9 @@
 module Roboservant.Types.Config where
 
 import Data.Dynamic
+import Data.List.NonEmpty (NonEmpty)
+import Roboservant.Types.Internal (Provenance)
+import Roboservant.Types.ReifiedApi (ApiOffset, InteractionError)
 
 data Config
   = Config
@@ -10,7 +13,28 @@ data Config
         rngSeed :: Int,
         coverageThreshold :: Double,
         logInfo :: String -> IO (),
-        healthCheck :: IO ()
+        healthCheck :: IO (),
+        traceChecks :: [TraceCheck]
+      }
+
+data TraceResult
+  = TraceSuccess (NonEmpty Dynamic)
+  | TraceError InteractionError
+  deriving (Show)
+
+data CallTrace
+  = CallTrace
+      { ctOffset :: ApiOffset,
+        ctProvenance :: [Provenance],
+        ctArguments :: [Dynamic],
+        ctResult :: TraceResult
+      }
+  deriving (Show)
+
+data TraceCheck
+  = TraceCheck
+      { traceCheckName :: String,
+        traceCheck :: [CallTrace] -> Maybe String
       }
 
 defaultConfig :: Config
@@ -22,7 +46,8 @@ defaultConfig =
       rngSeed = 0,
       coverageThreshold = 0,
       logInfo = const (pure ()),
-      healthCheck = pure ()
+      healthCheck = pure (),
+      traceChecks = []
     }
 
 noisyConfig :: Config

--- a/test/MinithesisAuth.hs
+++ b/test/MinithesisAuth.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+
+module MinithesisAuth where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Hashable (Hashable)
+import GHC.Generics (Generic)
+import Servant
+
+newtype Token = Token Int
+  deriving stock (Eq, Show, Generic)
+  deriving newtype (Hashable, FromJSON, ToJSON, FromHttpApiData, ToHttpApiData)
+
+type Api =
+  "login" :> Get '[JSON] Token
+    :<|> "protected" :> Capture "token" Token :> Get '[JSON] ()
+
+server :: Server Api
+server =
+  pure (Token 42)
+    :<|> protected
+
+protected :: Token -> Handler ()
+protected token
+  | token == Token 42 = pure ()
+  | otherwise = throwError err401 {errBody = "unauthorized"}


### PR DESCRIPTION
## Summary
- capture per-call traces and expose configurable trace checks in the fuzzing config
- surface trace check failures from the fuzzer so minithesis can shrink sequences beyond hard crashes
- add a MinithesisAuth regression fixture covering 401-only failures via a new Hspec trace-check test

## Testing
- stack test
