### PR TITLE
Buffer server fuzz logs

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ tests:
     - aeson >= 1.5 && < 2.3
     - http-api-data >= 0.4 && < 0.7
     - http-client >= 0.5 && < 0.8
+    - silently >= 0.3 && < 1.3
     - network >= 3.1 && < 3.3
     - sydtest >= 0.15 && < 0.22
     - wai >= 3.2 && < 3.3

--- a/roboservant.cabal
+++ b/roboservant.cabal
@@ -150,6 +150,7 @@ test-suite roboservant-test
     , servant-client >=0.18 && <0.21
     , servant-flatten ==0.2.*
     , servant-server >=0.18 && <0.21
+    , silently >=0.3 && <1.3
     , string-conversions ==0.4.*
     , sydtest >=0.15 && <0.22
     , text >=1.2 && <2.2


### PR DESCRIPTION
## Summary
- capture stdout/stderr while running server fuzz tests so noisy logs only surface on failure
- wrap server assertions in a context that reports buffered logs for easier debugging
- add the silently dependency for test builds

## Testing
- stack test
