### PR TITLE
Add remote fuzzing helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,29 @@ dictionary. This means that they are now available for the
 prerequisites of other calls, so as you proceed, more and more api
 calls become possible.
 
+### fuzzing remote servers
+
+You don't have to embed the server under test in-process. If you have
+an instance running elsewhere that implements the same Servant API, you
+can point Roboservant at its base URL and let the fuzzer drive the
+endpoints:
+
+``` haskell
+import qualified Roboservant.Client as RC
+import qualified Roboservant as R
+import Servant.Client (parseBaseUrl)
+
+checkRemote :: IO ()
+checkRemote = do
+  base <- either (fail . show) pure (parseBaseUrl "http://localhost:8080")
+  RC.fuzzBaseUrl @Api base R.defaultConfig >>= \case
+    Nothing -> putStrLn "remote server looks healthy"
+    Just report -> print report
+```
+
+For quick scripts you can also pass the URL as a string and let
+Roboservant parse it for you with `fuzzUrl`.
+
 We explicitly do not try to come up with plausible values that haven't
 somehow come back from the API. That's straying into QC/Hedgehog
 territory: if you want that, come up with the values on that side, and

--- a/package.yaml
+++ b/package.yaml
@@ -20,6 +20,7 @@ dependencies:
 - containers >= 0.6 && < 0.9
 - random >= 1.2 && < 1.4
 - hashable >= 1.4 && < 1.6
+- http-client >= 0.5 && < 0.8
 - http-types >= 0.12 && < 0.13
 - lifted-base >= 0.2 && < 0.3
 - monad-control >= 1.0 && < 1.1

--- a/roboservant.cabal
+++ b/roboservant.cabal
@@ -50,6 +50,7 @@ library
     , dependent-map ==0.4.*
     , dependent-sum ==0.7.*
     , hashable >=1.4 && <1.6
+    , http-client >=0.5 && <0.8
     , http-types ==0.12.*
     , lifted-base ==0.2.*
     , minithesis ==0.1.*


### PR DESCRIPTION
## Summary
- add client helpers that fuzz a Servant API via BaseUrl/URL strings while creating their own ClientEnv
- cover the regression with tests that spin up a local Warp server and hit it using the new helpers
- document remote fuzz usage in the README with a minimal example

## Testing
- stack test
