### PR TITLE
Add detailed HTTP trace reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ dist-newstyle/
 .stack-work/
 .hie/
 *~
-.minithesis-db/
+.minithesis-db

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist-newstyle/
 .stack-work/
 .hie/
 *~
+.minithesis-db/

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ RS.fuzz @Api server config >>= (`shouldBe` Nothing)
 ### reading failure reports
 
 When a fuzz run fails, Roboservant prints the minimized HTTP trace that
-triggered the issue and stores it under `.minithesis-db/roboservant-runs/<run-id>`
-for later inspection. A failure now renders each call with its method, URL
+triggered the issue and stores it in `.minithesis-db` for later
+inspection. A failure now renders each call with its method, URL
 segments, query parameters, headers, and payloads. For example:
 
 ```
@@ -128,8 +128,8 @@ POST /checkout?id=42 -> ok
 GET /fail/777 -> ERROR explosion (fatal)
 ```
 
-The same trace is persisted under `.minithesis-db/roboservant-runs/<run-id>`,
-so you can replay or extend the reproducer later.
+The same trace is persisted in `.minithesis-db`, so you can replay or extend the
+reproducer later.
 
 We explicitly do not try to come up with plausible values that haven't
 somehow come back from the API. That's straying into QC/Hedgehog
@@ -203,8 +203,7 @@ these without context via Arbitrary.
 Failure traces now contain the exact operations that ran (including
 URLs, query parameters, headers, bodies, and responses) and can be
 checked with `TraceCheck`s. Minithesis shrinks and persists the
-smallest failing sequence in `.minithesis-db/roboservant-runs/<run-id>`
-for later inspection.
+smallest failing sequence in `.minithesis-db` for later inspection.
 
 Support for recursive datatypes still requires hand-written
 `BuildFrom` instances to avoid infinite loops. Deriving those

--- a/README.md
+++ b/README.md
@@ -114,6 +114,23 @@ let config =
 RS.fuzz @Api server config >>= (`shouldBe` Nothing)
 ```
 
+### reading failure reports
+
+When a fuzz run fails, Roboservant prints the minimized HTTP trace that
+triggered the issue and stores it under `.minithesis-db/roboservant-runs/<run-id>`
+for later inspection. A failure now renders each call with its method, URL
+segments, query parameters, headers, and payloads. For example:
+
+```
+POST /checkout?id=42 -> ok
+  body: {"item":"widget","quantity":3}
+  response: {"orderId":"8b9f6e"}
+GET /fail/777 -> ERROR explosion (fatal)
+```
+
+The same trace is persisted under `.minithesis-db/roboservant-runs/<run-id>`,
+so you can replay or extend the reproducer later.
+
 We explicitly do not try to come up with plausible values that haven't
 somehow come back from the API. That's straying into QC/Hedgehog
 territory: if you want that, come up with the values on that side, and
@@ -183,11 +200,11 @@ these without context via Arbitrary.
 
 ## limitations and future work
 
-Failure traces now contain the exact operations that ran and can be
-checked with `TraceCheck`s, but their presentation is still pretty raw
-and not yet minimal. A future iteration should provide rerunnable
-traces and first-class shrinking support so users can examine the
-shortest interesting sequence.
+Failure traces now contain the exact operations that ran (including
+URLs, query parameters, headers, bodies, and responses) and can be
+checked with `TraceCheck`s. Minithesis shrinks and persists the
+smallest failing sequence in `.minithesis-db/roboservant-runs/<run-id>`
+for later inspection.
 
 Support for recursive datatypes still requires hand-written
 `BuildFrom` instances to avoid infinite loops. Deriving those

--- a/README.md
+++ b/README.md
@@ -27,6 +27,31 @@ dictionary. This means that they are now available for the
 prerequisites of other calls, so as you proceed, more and more api
 calls become possible.
 
+### fuzzing with sydtest
+
+```haskell
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+import qualified Roboservant as R
+import qualified Roboservant.Server as RS
+import Servant (Get, JSON, Proxy (..), (:>), Server)
+import Test.Syd
+
+type Api = "ping" :> Get '[JSON] Int
+
+server :: Server Api
+server = pure 42
+
+main :: IO ()
+main = sydTest $ do
+  describe "ping api" $
+    it "stays healthy under fuzzing" $ do
+      RS.fuzz @Api server R.defaultConfig {R.maxReps = 200}
+        >>= (`shouldBe` Nothing)
+```
+
 ### fuzzing remote servers
 
 You don't have to embed the server under test in-process. If you have
@@ -34,21 +59,60 @@ an instance running elsewhere that implements the same Servant API, you
 can point Roboservant at its base URL and let the fuzzer drive the
 endpoints:
 
-``` haskell
+```haskell
 import qualified Roboservant.Client as RC
 import qualified Roboservant as R
 import Servant.Client (parseBaseUrl)
+import Test.Syd
 
-checkRemote :: IO ()
-checkRemote = do
-  base <- either (fail . show) pure (parseBaseUrl "http://localhost:8080")
-  RC.fuzzBaseUrl @Api base R.defaultConfig >>= \case
-    Nothing -> putStrLn "remote server looks healthy"
-    Just report -> print report
+remoteSpec :: Spec
+remoteSpec =
+  it "accepts the happy-path flow" $ do
+    base <- either (fail . show) pure (parseBaseUrl "http://localhost:8080")
+    RC.fuzzBaseUrl @Api base R.defaultConfig >>= (`shouldBe` Nothing)
+
+main :: IO ()
+main = sydTest remoteSpec
 ```
 
 For quick scripts you can also pass the URL as a string and let
 Roboservant parse it for you with `fuzzUrl`.
+
+### checking trace-level invariants
+
+Roboservant can evaluate predicates over the entire sequence of calls
+by attaching `TraceCheck`s to the configuration. Use this to catch
+subtle behaviours (for example, a 401 emitted before authentication is
+complete):
+
+```haskell
+import Data.List (find)
+import qualified Data.Text as T
+import qualified Roboservant as R
+import qualified Roboservant.Server as RS
+
+noUnauthorized :: [R.CallTrace] -> Maybe String
+noUnauthorized calls =
+  case find isUnauthorized calls of
+    Nothing -> Nothing
+    Just _ -> Just "encountered 401 before authorization"
+  where
+    isUnauthorized R.CallTrace {R.ctResult = R.TraceError err} =
+      (not . R.fatalError) err && "401" `T.isInfixOf` R.errorMessage err
+    isUnauthorized _ = False
+
+let config =
+      R.defaultConfig
+        { R.traceChecks =
+            [ R.TraceCheck
+                { R.traceCheckName = "no unauthorized",
+                  R.traceCheck = noUnauthorized
+                }
+            ]
+        }
+
+RS.fuzz @Api server config >>= (`shouldBe` Nothing)
+```
 
 We explicitly do not try to come up with plausible values that haven't
 somehow come back from the API. That's straying into QC/Hedgehog
@@ -119,23 +183,16 @@ these without context via Arbitrary.
 
 ## limitations and future work
 
-Currently, the display of failing traces is pretty tragic, both in the
-formatting and in its non-minimality. This is pretty ticklish:
-arguably the right way to do this is to return a trace that we can
-also rerun, and let quickcheck or hedgehog a level up shrink it until
-it's satisfactorily short. In the interest of being useful earlier
-rather than later, I'm releasing v1.0 before I crack this particular
-nut. We do know which calls we made that led to the failing case, so
-we would want to show that distinction in a visible way: it's possible
-that other calls that don't have direct data dependencies were
-important, but we definitely know we need the direct data dependencies.
+Failure traces now contain the exact operations that ran and can be
+checked with `TraceCheck`s, but their presentation is still pretty raw
+and not yet minimal. A future iteration should provide rerunnable
+traces and first-class shrinking support so users can examine the
+shortest interesting sequence.
 
-The provenance stuff is a bit underbaked. It should at least pull a
-representation of the route chosen rather than just an integer index.
+Support for recursive datatypes still requires hand-written
+`BuildFrom` instances to avoid infinite loops. Deriving those
+automatically (or rejecting problematic definitions earlier) remains
+on the roadmap.
 
-It would also be nice to have a robust strategy for deriving recursive
-datatypes, or at least rejecting attempts to generate them that don't
-end in an infinite loop.
-
-Currently the `FlattenServer` instance for `:>` is quadratic. It would
-be nice to fix this but I lack the art.
+Finally, the `FlattenServer` instance for `:>` is still quadratic. A
+more efficient representation would make large APIs cheaper to fuzz.

--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,10 @@ dependencies:
 - monad-control >= 1.0 && < 1.1
 - mtl >= 2.2 && < 2.4
 - minithesis >= 0.1 && < 0.2
+- aeson >= 1.5 && < 2.3
+- scientific >= 0.3 && < 0.4
+- base64-bytestring >= 1.0 && < 1.3
+- directory >= 1.3 && < 1.4
 - servant >= 0.18 && < 0.21
 - servant-client >= 0.18 && < 0.21
 - servant-flatten >= 0.2 && < 0.3
@@ -34,6 +38,7 @@ dependencies:
 - vinyl >= 0.13 && < 0.15
 - dependent-sum >= 0.7 && < 0.8
 - dependent-map >= 0.4 && < 0.5
+- filepath >= 1.4 && < 1.6
 - unordered-containers >= 0.2.10 && < 0.3
 - text >= 1.2 && < 2.2
 - time >= 1.9 && < 1.16

--- a/roboservant.cabal
+++ b/roboservant.cabal
@@ -50,6 +50,7 @@ library
     , dependent-map ==0.4.*
     , dependent-sum ==0.7.*
     , hashable >=1.4 && <1.6
+    , aeson >=1.5 && <2.3
     , http-client >=0.5 && <0.8
     , http-types ==0.12.*
     , lifted-base ==0.2.*
@@ -57,10 +58,14 @@ library
     , monad-control ==1.0.*
     , mtl >=2.2 && <2.4
     , random >=1.2 && <1.4
+    , directory >=1.3 && <1.4
     , servant >=0.18 && <0.21
     , servant-client >=0.18 && <0.21
     , servant-flatten ==0.2.*
     , servant-server >=0.18 && <0.21
+    , scientific >=0.3 && <0.4
+    , base64-bytestring >=1.0 && <1.3
+    , filepath >=1.4 && <1.6
     , string-conversions ==0.4.*
     , text >=1.2 && <2.2
     , time >=1.9 && <1.16
@@ -123,6 +128,7 @@ test-suite roboservant-test
       QueryParams
       Records
       Seeded
+      SummaryExample
       UnsafeIO
       Valid
       Paths_roboservant

--- a/src/Roboservant/Client.hs
+++ b/src/Roboservant/Client.hs
@@ -117,6 +117,7 @@ instance
     (0, ReifiedEndpoint
         { reArguments    = reifiedEndpointArguments @endpoint
         , reEndpointFunc = foo (normalize endpoint)
+        , reDoc = reifiedEndpointDoc @endpoint
         }
     )
     : (map . first) (+1)

--- a/src/Roboservant/Types/ReifiedApi/Server.hs
+++ b/src/Roboservant/Types/ReifiedApi/Server.hs
@@ -71,6 +71,7 @@ instance
     (0, ReifiedEndpoint
          { reArguments    = reifiedEndpointArguments @endpoint
          , reEndpointFunc = normalize endpoint
+         , reDoc = reifiedEndpointDoc @endpoint
          }
     )
       : (map . first) (+1)

--- a/test/SummaryExample.hs
+++ b/test/SummaryExample.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module SummaryExample where
+
+import Servant
+
+-- | Minimal API with a required query parameter and JSON body so we can
+-- exercise call summary rendering in tests.
+type Api =
+  "summary" :> QueryParam' '[Required] "id" Int :> ReqBody '[JSON] Int :> Post '[JSON] Int
+
+server :: Server Api
+server ident payload = pure (ident + payload)


### PR DESCRIPTION
Summary:
- record per-call method/path/query/header/body/response info in the stored trace and surface it in failure output
- persist minithesis runs under unique `.minithesis-db/roboservant-runs/<run-id>` directories and cover the formatting with a sydtest fixture
- refresh the README to drop the provenance disclaimer and describe the new reporting behaviour

Testing:
- stack test
