### PR TITLE
Expose Minithesis property in tests

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -39,6 +39,9 @@ jobs:
           path: |
             ~/.cabal
           key: ${{ runner.os }}-${{ matrix.versions.ghc }}-${{ matrix.versions.cabal }}-cabal-global-${{ hashFiles('cabal.project') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.versions.ghc }}-${{ matrix.versions.cabal }}-cabal-global-
+            ${{ runner.os }}-${{ matrix.versions.ghc }}-${{ matrix.versions.cabal }}-
 
       - name: Cache cabal build
         id: cabal-local

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Test
         run: |
-          cabal test all --disable-optimization
+          cabal test all --enable-tests --disable-optimization
 
       - name: cabal check
         run: cabal check

--- a/cabal.project
+++ b/cabal.project
@@ -6,4 +6,10 @@ source-repository-package
   tag: 2ee9e15077fb95850318eb7fca33c49a7fd45fa8
   subdir: minithesis
 
+source-repository-package
+  type: git
+  location: https://github.com/lambdamechanic/minithesis-hs.git
+  tag: 2ee9e15077fb95850318eb7fca33c49a7fd45fa8
+  subdir: minithesis-sydtest
+
 constraints: envparse < 0.6

--- a/package.yaml
+++ b/package.yaml
@@ -63,6 +63,7 @@ tests:
     - aeson >= 1.5 && < 2.3
     - http-api-data >= 0.4 && < 0.7
     - http-client >= 0.5 && < 0.8
+    - minithesis-sydtest >= 0.1 && < 0.2
     - silently >= 0.3 && < 1.3
     - network >= 3.1 && < 3.3
     - sydtest >= 0.15 && < 0.22

--- a/roboservant.cabal
+++ b/roboservant.cabal
@@ -44,13 +44,16 @@ library
       src
   ghc-options: -Wall -fwrite-ide-info -hiedir=.hie
   build-depends:
-      base >=4.7 && <4.22
+      aeson >=1.5 && <2.3
+    , base >=4.7 && <4.22
+    , base64-bytestring >=1.0 && <1.3
     , bytestring >=0.11 && <0.13
     , containers >=0.6 && <0.9
     , dependent-map ==0.4.*
     , dependent-sum ==0.7.*
+    , directory ==1.3.*
+    , filepath >=1.4 && <1.6
     , hashable >=1.4 && <1.6
-    , aeson >=1.5 && <2.3
     , http-client >=0.5 && <0.8
     , http-types ==0.12.*
     , lifted-base ==0.2.*
@@ -58,14 +61,11 @@ library
     , monad-control ==1.0.*
     , mtl >=2.2 && <2.4
     , random >=1.2 && <1.4
-    , directory >=1.3 && <1.4
+    , scientific ==0.3.*
     , servant >=0.18 && <0.21
     , servant-client >=0.18 && <0.21
     , servant-flatten ==0.2.*
     , servant-server >=0.18 && <0.21
-    , scientific >=0.3 && <0.4
-    , base64-bytestring >=1.0 && <1.3
-    , filepath >=1.4 && <1.6
     , string-conversions ==0.4.*
     , text >=1.2 && <2.2
     , time >=1.9 && <1.16
@@ -86,10 +86,13 @@ test-suite example
   build-depends:
       aeson >=1.5 && <2.3
     , base >=4.7 && <4.22
+    , base64-bytestring >=1.0 && <1.3
     , bytestring >=0.11 && <0.13
     , containers >=0.6 && <0.9
     , dependent-map ==0.4.*
     , dependent-sum ==0.7.*
+    , directory ==1.3.*
+    , filepath >=1.4 && <1.6
     , hashable >=1.4 && <1.6
     , http-client >=0.5 && <0.8
     , http-types ==0.12.*
@@ -99,6 +102,7 @@ test-suite example
     , mtl >=2.2 && <2.4
     , random >=1.2 && <1.4
     , roboservant
+    , scientific ==0.3.*
     , servant >=0.18 && <0.21
     , servant-client >=0.18 && <0.21
     , servant-flatten ==0.2.*
@@ -119,8 +123,8 @@ test-suite roboservant-test
       Breakdown
       Foo
       Headers
-      MinithesisExample
       MinithesisAuth
+      MinithesisExample
       Nested
       Post
       Product
@@ -138,21 +142,26 @@ test-suite roboservant-test
   build-depends:
       aeson >=1.5 && <2.3
     , base >=4.7 && <4.22
+    , base64-bytestring >=1.0 && <1.3
     , bytestring >=0.11 && <0.13
     , containers >=0.6 && <0.9
     , dependent-map ==0.4.*
     , dependent-sum ==0.7.*
+    , directory ==1.3.*
+    , filepath >=1.4 && <1.6
     , hashable >=1.4 && <1.6
     , http-api-data >=0.4 && <0.7
     , http-client >=0.5 && <0.8
     , http-types ==0.12.*
     , lifted-base ==0.2.*
     , minithesis ==0.1.*
+    , minithesis-sydtest ==0.1.*
     , monad-control ==1.0.*
     , mtl >=2.2 && <2.4
     , network >=3.1 && <3.3
     , random >=1.2 && <1.4
     , roboservant
+    , scientific ==0.3.*
     , servant >=0.18 && <0.21
     , servant-client >=0.18 && <0.21
     , servant-flatten ==0.2.*

--- a/src/Roboservant/Server.hs
+++ b/src/Roboservant/Server.hs
@@ -5,32 +5,61 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
-
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Roboservant.Server (fuzz, module Roboservant.Types ) where
+module Roboservant.Server
+  ( fuzz,
+    fuzzProperty,
+    fuzzTestCase,
+    module Roboservant.Types
+  )
+where
 
-import Roboservant.Direct(fuzz',Report)
+import Minithesis (Property, TestCase)
+import qualified Roboservant.Direct as RD
+import Roboservant.Direct (Report)
 import Roboservant.Types
   ( FlattenServer (..),
     ReifiedApi,
   )
-import Roboservant.Types.ReifiedApi.Server(ToReifiedApi (..))
-import Servant (Endpoints, Proxy (Proxy), Server)
 import Roboservant.Types.Config
+import Roboservant.Types.ReifiedApi.Server (ToReifiedApi (..))
+import Servant (Endpoints, Proxy (Proxy), Server)
 
-fuzz :: forall api.
-              (FlattenServer api, ToReifiedApi (Endpoints api)) =>
-              Server api ->
-              Config ->
-              IO (Maybe Report)
-fuzz s  = fuzz' (reifyServer s)
-  -- todo: how do we pull reifyServer out?
-  where reifyServer :: (FlattenServer api, ToReifiedApi (Endpoints api))
-                    => Server api -> ReifiedApi
-        reifyServer server = toReifiedApi (flattenServer @api server) (Proxy @(Endpoints api))
---        reifyServer server = toReifiedApi server (Proxy @(Endpoints api))
+fuzz ::
+  forall api.
+  (FlattenServer api, ToReifiedApi (Endpoints api)) =>
+  Server api ->
+  Config ->
+  IO (Maybe Report)
+fuzz server = RD.fuzz' (reifyServer @api server)
 
+fuzzProperty ::
+  forall api.
+  (FlattenServer api, ToReifiedApi (Endpoints api)) =>
+  Server api ->
+  Config ->
+  Property
+fuzzProperty server = RD.fuzzProperty (reifyServer @api server)
+
+fuzzTestCase ::
+  forall api.
+  (FlattenServer api, ToReifiedApi (Endpoints api)) =>
+  Server api ->
+  Config ->
+  TestCase ->
+  IO (Maybe Report)
+fuzzTestCase server = RD.runFuzzTestCase (reifyServer @api server)
+
+reifyServer ::
+  forall api.
+  (FlattenServer api, ToReifiedApi (Endpoints api)) =>
+  Server api ->
+  ReifiedApi
+reifyServer server =
+  toReifiedApi
+    (flattenServer @api server)
+    (Proxy @(Endpoints api))

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,4 +12,5 @@ extra-deps:
   commit: 2ee9e15077fb95850318eb7fca33c49a7fd45fa8
   subdirs:
     - minithesis
+    - minithesis-sydtest
 - sydtest-0.21.0.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -32,6 +32,19 @@ packages:
     git: https://github.com/lambdamechanic/minithesis-hs.git
     subdir: minithesis
 - completed:
+    commit: 2ee9e15077fb95850318eb7fca33c49a7fd45fa8
+    git: https://github.com/lambdamechanic/minithesis-hs.git
+    name: minithesis-sydtest
+    pantry-tree:
+      sha256: d6b392a3b80db52b6ecacbe84f58cfdf48ab2fa62b177d2c36976124bd49e61a
+      size: 233
+    subdir: minithesis-sydtest
+    version: 0.1.0.0
+  original:
+    commit: 2ee9e15077fb95850318eb7fca33c49a7fd45fa8
+    git: https://github.com/lambdamechanic/minithesis-hs.git
+    subdir: minithesis-sydtest
+- completed:
     hackage: sydtest-0.21.0.0@sha256:cffa077d86a835a7031735abf8922b1781f023100988d09880ff87357877e82f,2425
     pantry-tree:
       sha256: 40ad88d0081e463b5018d1dffeb41a4276e08f835f6fb0cc61d39a4f4d142c97


### PR DESCRIPTION
## Summary
- expose reusable Minithesis property/test-case helpers for fuzzing and wire RS/RC fuzzers through them
- integrate minithesis-sydtest into the spec suite and add deterministic call-summary expectations
- enrich call summaries with request-first formatting and HTTP status reporting for clearer failures

## Testing
- stack test
